### PR TITLE
Add dependency on 'rb-inotify'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
 gem 'github-pages'
+gem 'rb-inotify'


### PR DESCRIPTION
Without this gem, starting `bundle exec jekyll serve` fails.
