### PR TITLE
Add bundler dependency on 'json'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'github-pages'
+gem 'github-pages', group: :jekyll_plugins
+gem 'json'
 gem 'rb-inotify'


### PR DESCRIPTION
Without this gem, starting `bundle exec jekyll serve` fails.
